### PR TITLE
Fix rules for finding Homebrew taps

### DIFF
--- a/homebrew-mode.el
+++ b/homebrew-mode.el
@@ -260,15 +260,21 @@ Otherwise return nil."
     (let ((root (homebrew--get-taps-dir))
           (taps '())
           (case-fold-search nil))
-      (dolist (user (directory-files root nil "^[^.]") taps)
-        (dolist (repo (directory-files (concat root user) nil "^[^.]"))
-          (let ((dot-git (concat root user "/" repo "/" ".git")))
-            (when (file-exists-p dot-git)
-              (let ((tap (concat user "/"
-                                 (if (string-match "^homebrew-\\(.*\\)" repo)
-                                     (match-string 1 repo)
-                                     repo))))
-                (push tap taps)))))))))
+      (dolist (user (directory-files root) taps)
+        (unless (member user '("." ".."))
+          (let ((root-user (concat root (file-name-as-directory user))))
+            (when (file-directory-p root-user)
+              (dolist (repo (directory-files root-user))
+                (unless (member repo '("." ".."))
+                  (let ((root-user-repo
+                         (concat root-user (file-name-as-directory repo))))
+                    (when (file-directory-p root-user-repo)
+                      (let ((tap (concat
+                                  user "/"
+                                  (if (string-match "^homebrew-\\(.*\\)" repo)
+                                      (match-string 1 repo)
+                                    repo))))
+                        (push tap taps)))))))))))))
 
 (defun homebrew--get-tap-dir (tap)
   "Return the full directory pathname of a Homebrew TAP, or nil."


### PR DESCRIPTION
to better match what `brew tap` does.

- Look only for directories, not files.

- Directories starting with dots are NOT ignored.

- ".git" is not treated specially. Taps don't have to contain a ".git"
  directory.